### PR TITLE
Install dependencies during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,6 +27,7 @@ fi
 echo "[setup]: Installing elixir dependencies"
 MIX_ENV=$env mix local.hex --force
 MIX_ENV=$env mix local.rebar --force
+MIX_ENV=$env mix deps.get
 
 echo "[setup]: Setting up node"
 ensure_yarn_exists


### PR DESCRIPTION
Just actually install the dependencies with `mix deps.get`, so `yarn` does not crash when looking for the `phoenix` dep.