### PR TITLE
Automatically create a game when starting the app.

### DIFF
--- a/apps/pong/config/config.exs
+++ b/apps/pong/config/config.exs
@@ -2,6 +2,10 @@ use Mix.Config
 
 config :pong, Pong, fps: 60
 
+config :pong, Pong.Game.Board,
+  width: 1000,
+  height: 1000
+
 config :pong, Pong.Game.Ball,
   start_x: 250,
   start_y: 250,

--- a/apps/pong/lib/application.ex
+++ b/apps/pong/lib/application.ex
@@ -1,0 +1,11 @@
+defmodule Pong.Application do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    children = [Pong]
+
+    opts = [strategy: :one_for_one, name: Pong.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/pong/lib/pong.ex
+++ b/apps/pong/lib/pong.ex
@@ -7,14 +7,8 @@ defmodule Pong do
 
   @fps 60
 
-  def start(board_width, board_height) do
-    opts = [
-      fps: config(Pong, :fps, @fps),
-      board_width: board_width,
-      board_height: board_height
-    ]
-
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def join do
@@ -29,14 +23,10 @@ defmodule Pong do
     GenServer.cast(__MODULE__, {:move, player, direction})
   end
 
-  def init(opts) do
-    fps = Keyword.fetch!(opts, :fps)
-    board_width = Keyword.fetch!(opts, :board_width)
-    board_height = Keyword.fetch!(opts, :board_height)
-
+  def init(:ok) do
     state = %{
-      game: Game.new(board_width, board_height),
-      fps: fps,
+      game: Game.new(),
+      fps: config(Pong, :fps, @fps),
       player_left: nil,
       player_right: nil
     }
@@ -60,6 +50,10 @@ defmodule Pong do
     end
   end
 
+  def handle_call({:leave, player_id}, _from, state) do
+    {:reply, :ok, remove_player(player_id, state)}
+  end
+
   defp add_player(%{player_left: nil} = state),
     do: {:ok, :left, %{state | player_left: true}}
 
@@ -68,10 +62,6 @@ defmodule Pong do
 
   defp add_player(_),
     do: {:error, :game_full}
-
-  def handle_call({:leave, player_id}, _from, state) do
-    {:reply, :ok, remove_player(player_id, state)}
-  end
 
   defp remove_player(:left, state),
     do: %{state | player_left: nil}

--- a/apps/pong/lib/pong/game.ex
+++ b/apps/pong/lib/pong/game.ex
@@ -14,15 +14,16 @@ defmodule Pong.Game do
   @type t :: %__MODULE__{}
   @type player_ref :: :left | :right
 
-  @spec new(integer(), integer()) :: Game.t()
-  def new(board_width, board_height) do
+  @spec new :: Game.t()
+  def new do
     paddle_margin = config!(Paddle, :start_x)
+    board = Board.new()
 
     %__MODULE__{
       ball: Ball.new(),
-      board: Board.new(board_width, board_height),
+      board: board,
       paddle_left: Paddle.new(paddle_margin),
-      paddle_right: Paddle.new(board_width - paddle_margin)
+      paddle_right: Paddle.new(board.width - paddle_margin)
     }
   end
 

--- a/apps/pong/lib/pong/game/board.ex
+++ b/apps/pong/lib/pong/game/board.ex
@@ -6,13 +6,15 @@ defmodule Pong.Game.Board do
 
   alias __MODULE__
 
+  import Pong.Config, only: [config!: 2]
+
   @type t :: %__MODULE__{}
 
-  @spec new(integer(), integer()) :: Board.t()
-  def new(width, length) do
+  @spec new :: Board.t()
+  def new do
     %__MODULE__{
-      width: width,
-      height: length
+      width: config!(Pong.Game.Board, :width),
+      height: config!(Pong.Game.Board, :height)
     }
   end
 end

--- a/apps/pong/mix.exs
+++ b/apps/pong/mix.exs
@@ -18,7 +18,8 @@ defmodule Pong.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Pong.Application, []}
     ]
   end
 


### PR DESCRIPTION
Why:

* Since we will be converting the internal game engine coordinates to the
frontend representation, we can now have a fixed board size internally.
* This means that we can add the board dimensions in the config and
automatically create a new game when the application starts, instead of passing
them in the initializer.

This change addresses the need by:

* Making the pong app an OTP application.
* Setting the game dimensions to be loaded by config.
* Creating a new game when the OTP app starts.