### PR TITLE
Broadcast the game state when the paddles move.

### DIFF
--- a/apps/client/frontend/components/Board/index.js
+++ b/apps/client/frontend/components/Board/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { Stage, Layer } from 'react-konva';
+import { Socket } from 'phoenix';
 
 import Paddle from '../Paddle';
 import RetroText from '../RetroText';
@@ -9,6 +10,60 @@ import RetroText from '../RetroText';
 import './index.css';
 
 export default class Board extends Component {
+  state = {
+    ball: null,
+    board: null,
+    paddle_left: null,
+    paddle_right: null,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.socket = new Socket('/socket');
+
+    this.socket.connect();
+    this.channel = this.socket.channel('game:board');
+    this.joinChannel();
+  }
+
+  componentWillUnmount() {
+    this.leaveChannel();
+  }
+
+  joinChannel = () => {
+    this.channel
+      .join()
+      .receive('ok', data => {
+        console.log('Joined successfully', data); // eslint-disable-line
+        this.setState(data);
+        this.subscribeToData();
+      })
+      .receive('error', resp => {
+        console.log('Unable to join', resp); // eslint-disable-line
+      });
+  };
+
+  leaveChannel = () => {
+    this.channel
+      .leave()
+      .receive('ok', resp => {
+        console.log('Left successfully', resp); // eslint-disable-line
+        this.socket.disconnect();
+      })
+      .receive('error', resp => {
+        console.log('Could not leave the channel!', resp); // eslint-disable-line
+        this.socket.disconnect();
+      });
+  };
+
+  subscribeToData = () => {
+    this.channel.on('data', data => {
+      this.setState(data);
+      console.log(data);
+    });
+  };
+
   static propTypes = {
     width: PropTypes.number,
     height: PropTypes.number,

--- a/apps/client/lib/client/application.ex
+++ b/apps/client/lib/client/application.ex
@@ -1,29 +1,20 @@
 defmodule Client.Application do
   use Application
 
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec
 
-    # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
       supervisor(Client.Repo, []),
-      # Start the endpoint when the application starts
-      supervisor(ClientWeb.Endpoint, []),
-      # Start your own worker by calling: Client.Worker.start_link(arg1, arg2, arg3)
-      # worker(Client.Worker, [arg1, arg2, arg3]),
+      supervisor(ClientWeb.Endpoint, [])
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
+    Client.PongSubscription.create()
+
     opts = [strategy: :one_for_one, name: Client.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   def config_change(changed, _new, removed) do
     ClientWeb.Endpoint.config_change(changed, removed)
     :ok

--- a/apps/client/lib/client/pong_subscription.ex
+++ b/apps/client/lib/client/pong_subscription.ex
@@ -1,0 +1,9 @@
+defmodule Client.PongSubscription do
+  def create do
+    Pong.subscribe(&broadcast_data/1)
+  end
+
+  defp broadcast_data(data) do
+    ClientWeb.Endpoint.broadcast("game:board", "data", data)
+  end
+end

--- a/apps/client/lib/client_web/channels/game_channel.ex
+++ b/apps/client/lib/client_web/channels/game_channel.ex
@@ -5,6 +5,12 @@ defmodule ClientWeb.Channels.GameChannel do
     {:ok, socket}
   end
 
+  def join("game:board", _params, socket) do
+    current_state = Pong.game_state()
+
+    {:ok, current_state, socket}
+  end
+
   def join("game:play", _params, socket) do
     case Pong.join() do
       {:ok, player_id} ->
@@ -15,9 +21,11 @@ defmodule ClientWeb.Channels.GameChannel do
     end
   end
 
-  def terminate(msg, socket) do
-    Pong.leave(socket.assigns.player_id)
+  def terminate(_msg, %{assigns: %{player_id: player_id}}) do
+    Pong.leave(player_id)
   end
+
+  def terminate(_, _), do: :ok
 
   def handle_in("player:move", %{"direction" => direction}, socket)
       when direction in ["up", "down"] do

--- a/apps/client/lib/client_web/channels/user_socket.ex
+++ b/apps/client/lib/client_web/channels/user_socket.ex
@@ -7,5 +7,5 @@ defmodule ClientWeb.UserSocket do
 
   def connect(_params, socket), do: {:ok, socket}
 
-  def id(socket), do: nil
+  def id(_socket), do: nil
 end

--- a/apps/pong/lib/pong.ex
+++ b/apps/pong/lib/pong.ex
@@ -19,6 +19,14 @@ defmodule Pong do
     GenServer.call(__MODULE__, {:leave, player_id})
   end
 
+  def game_state do
+    GenServer.call(__MODULE__, :game_state)
+  end
+
+  def subscribe(fun) when is_function(fun, 1) do
+    GenServer.cast(__MODULE__, {:subscribe, fun})
+  end
+
   def move(player, direction) do
     GenServer.cast(__MODULE__, {:move, player, direction})
   end
@@ -28,7 +36,8 @@ defmodule Pong do
       game: Game.new(),
       fps: config(Pong, :fps, @fps),
       player_left: nil,
-      player_right: nil
+      player_right: nil,
+      subscriptions: []
     }
 
     {:ok, state}
@@ -36,8 +45,15 @@ defmodule Pong do
 
   def handle_cast({:move, player, direction}, %{game: game} = state) do
     updated_game = Game.move(game, player, direction)
+    new_state = %{state | game: updated_game}
 
-    {:noreply,  %{state | game: updated_game}}
+    broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_cast({:subscribe, sub}, %{subscriptions: subscriptions} = state) do
+    {:noreply, %{state | subscriptions: [sub | subscriptions]}}
   end
 
   def handle_call(:join, _from, state) do
@@ -54,21 +70,25 @@ defmodule Pong do
     {:reply, :ok, remove_player(player_id, state)}
   end
 
+  def handle_call(:game_state, _from, state) do
+    {:reply, state.game, state}
+  end
+
   defp add_player(%{player_left: nil} = state),
     do: {:ok, :left, %{state | player_left: true}}
 
   defp add_player(%{player_right: nil} = state),
     do: {:ok, :right, %{state | player_right: true}}
 
-  defp add_player(_),
-    do: {:error, :game_full}
+  defp add_player(_), do: {:error, :game_full}
 
-  defp remove_player(:left, state),
-    do: %{state | player_left: nil}
+  defp remove_player(:left, state), do: %{state | player_left: nil}
+  defp remove_player(:right, state), do: %{state | player_right: nil}
+  defp remove_player(_, state), do: state
 
-  defp remove_player(:right, state),
-    do: %{state | player_right: nil}
-
-  defp remove_player(_, state),
-    do: state
+  defp broadcast(%{subscriptions: subscriptions, game: game}) do
+    for sub <- subscriptions do
+      sub.(game)
+    end
+  end
 end


### PR DESCRIPTION
Why:

* When the players move, we update the game state.
* To reflect the changes on the frontend we need to create a socket for the
board page and broadcast the state.

This change addresses the need by:

* Adding the socket on the Board component in the frontend.
* Adding subscriptions to the pong game -- This avoids calling the
broadcast directly from the pong game which creates a circular dependency.
* Calling the subscriptions whenever the players move.

Note:

* This depends on #6.