### PR TITLE
Correctly position paddles in the backend

### DIFF
--- a/apps/pong/config/config.exs
+++ b/apps/pong/config/config.exs
@@ -12,7 +12,6 @@ config :pong, Pong.Game.Ball,
   radius: 5
 
 config :pong, Pong.Game.Paddle,
-  start_x: 10,
-  start_y: 250,
-  width: 5,
-  height: 20
+  width: 10,
+  height: 100,
+  margin: 30

--- a/apps/pong/lib/pong/game.ex
+++ b/apps/pong/lib/pong/game.ex
@@ -21,14 +21,13 @@ defmodule Pong.Game do
 
   @spec new :: Game.t()
   def new do
-    paddle_margin = config!(Paddle, :start_x)
     board = Board.new()
 
     %__MODULE__{
       ball: Ball.new(),
       board: board,
-      paddle_left: Paddle.new(paddle_margin),
-      paddle_right: Paddle.new(board.width - paddle_margin)
+      paddle_left: Paddle.new(y: board.height / 2),
+      paddle_right: Paddle.new(y: board.height / 2, relative_to: board.width)
     }
   end
 

--- a/apps/pong/lib/pong/game/paddle.ex
+++ b/apps/pong/lib/pong/game/paddle.ex
@@ -17,12 +17,19 @@ defmodule Pong.Game.Paddle do
   alias __MODULE__
   alias Pong.Game.Board
 
-  @spec new(integer()) :: Paddle.t()
-  def new(start_x) do
-    start_y = config!(__MODULE__, :start_y)
+  @spec new(keyword()) :: Paddle.t()
+  def new(args) do
     height = config!(__MODULE__, :height)
+    margin = config!(__MODULE__, :margin)
     width = config!(__MODULE__, :width)
-    start_x = start_x + width / 2
+
+    start_y = Keyword.fetch!(args, :y)
+
+    start_x =
+      case Keyword.get(args, :relative_to) do
+        nil -> margin + width / 2
+        offset -> offset - margin - width / 2
+      end
 
     %__MODULE__{
       width: width,


### PR DESCRIPTION
Why:

* The right paddle was always stuck to the board end.
* The paddles had weird dimensions.

This change addresses the need by:

* Changing the dimensions of the paddle.
* Allowing the paddle's x coordinate to be set relative to an offset.