### PR TITLE
Attribute a fill to each paddle

### DIFF
--- a/apps/client/frontend/components/Board/index.js
+++ b/apps/client/frontend/components/Board/index.js
@@ -97,7 +97,7 @@ export default class Board extends Component {
       ball,
     } = positioning.repositionGame({
       dimensions: { width, height },
-      game: game,
+      game,
     });
 
     return (

--- a/apps/client/frontend/components/Paddle/index.js
+++ b/apps/client/frontend/components/Paddle/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import _ from 'lodash';
-import Konva from 'konva';
 import { Rect } from 'react-konva';
 
 export default class Paddle extends Component {
@@ -17,20 +16,13 @@ export default class Paddle extends Component {
       PropTypes.number.isRequired,
       PropTypes.func.isRequired,
     ]).isRequired,
-    fill: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    fill: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
     width: 20,
     height: 200,
-    fill: Konva.Util.getRandomColor,
   };
-
-  constructor(props) {
-    super(props);
-
-    this.fill = this.evalFill();
-  }
 
   evalCoordinate(coord) {
     const { width, height } = this.props;
@@ -42,18 +34,8 @@ export default class Paddle extends Component {
     return coord;
   }
 
-  evalFill() {
-    const { fill } = this.props;
-
-    if (_.isFunction(fill)) {
-      return fill();
-    }
-
-    return fill;
-  }
-
   render() {
-    const { width, height, x, y } = this.props;
+    const { width, height, x, y, fill } = this.props;
 
     return (
       <Rect
@@ -61,7 +43,7 @@ export default class Paddle extends Component {
         y={this.evalCoordinate(y) - height / 2}
         width={width}
         height={height}
-        fill={this.fill}
+        fill={fill}
       />
     );
   }

--- a/apps/client/frontend/lib/positioning.js
+++ b/apps/client/frontend/lib/positioning.js
@@ -69,10 +69,10 @@ const repositionGame = ({ dimensions, game }) => {
   const repositionedBall = repositionBall(dimensions, ratios, ball);
 
   return {
-    board,
+    ...game,
     ball: repositionedBall,
-    paddle_left: repositionedPaddleLeft,
-    paddle_right: repositionedPaddleRight,
+    paddle_left: { ...paddleLeft, ...repositionedPaddleLeft },
+    paddle_right: { ...paddleRight, ...repositionedPaddleRight },
   };
 };
 

--- a/apps/pong/config/config.exs
+++ b/apps/pong/config/config.exs
@@ -14,4 +14,20 @@ config :pong, Pong.Game.Ball,
 config :pong, Pong.Game.Paddle,
   width: 10,
   height: 100,
-  margin: 30
+  margin: 30,
+  fills: [
+    # anakiwa (cyan)
+    "#8BE9FD",
+    # screamin green
+    "#50FA7B",
+    # koromiko (orange)
+    "#FFB86C",
+    # hot pink
+    "#FF79C6",
+    # perfume (purple)
+    "#BD93F9",
+    # persimmon (red)
+    "#FF5555",
+    # honeysuckle (yellow)
+    "#F1FA8C"
+  ]

--- a/apps/pong/lib/pong/game.ex
+++ b/apps/pong/lib/pong/game.ex
@@ -21,11 +21,18 @@ defmodule Pong.Game do
   def new do
     board = Board.new()
 
+    [left_paddle_fill, right_paddle_fill] = Paddle.random_fills(2)
+
     %__MODULE__{
       ball: Ball.new(),
       board: board,
-      paddle_left: Paddle.new(y: board.height / 2),
-      paddle_right: Paddle.new(y: board.height / 2, relative_to: board.width)
+      paddle_left: Paddle.new(y: board.height / 2, fill: left_paddle_fill),
+      paddle_right:
+        Paddle.new(
+          y: board.height / 2,
+          relative_to: board.width,
+          fill: right_paddle_fill
+        )
     }
   end
 

--- a/apps/pong/lib/pong/game/paddle.ex
+++ b/apps/pong/lib/pong/game/paddle.ex
@@ -4,7 +4,8 @@ defmodule Pong.Game.Paddle do
     :height,
     :x,
     :y,
-    :speed
+    :speed,
+    :fill
   ]
 
   import Pong.Config, only: [config!: 2]
@@ -31,11 +32,14 @@ defmodule Pong.Game.Paddle do
         offset -> offset - margin
       end
 
+    fill = Keyword.get(args, :fill, random_fill())
+
     %__MODULE__{
       width: width,
       height: height,
       x: start_x,
       y: start_y,
+      fill: fill,
       speed: @default_speed
     }
   end
@@ -46,6 +50,16 @@ defmodule Pong.Game.Paddle do
     |> apply_vector(direction)
     |> prevent_overflow(board)
   end
+
+  @spec random_fills(integer()) :: String.t()
+  def random_fills(n) do
+    config!(__MODULE__, :fills)
+    |> Enum.shuffle()
+    |> Enum.take(n)
+  end
+
+  @spec random_fill :: String.t()
+  def random_fill, do: random_fills(1) |> List.first()
 
   defp apply_vector(%{y: y} = paddle, :up) do
     %{paddle | y: y + @default_speed}


### PR DESCRIPTION
Why:

* We players to have the background colors of their controller match
their paddle to better distinguish.
* To do that we need to make the backend attribute a fill to each
paddle.

This change addresses the need by:

* Adding the fill field to the paddle.
* Generating unique fills for the game paddles.
* Updating the paddle color with that same value.