### PR TITLE
Prevent the paddle from overflowing off the board.

### DIFF
--- a/apps/pong/lib/pong/game/paddle.ex
+++ b/apps/pong/lib/pong/game/paddle.ex
@@ -70,6 +70,11 @@ defmodule Pong.Game.Paddle do
   end
 
   defp prevent_overflow(paddle, board) do
-    %{paddle | y: min(paddle.y, board.height - paddle.height / 2)}
+    clamped_y =
+      paddle.y
+      |> min(board.height - paddle.height / 2)
+      |> max(paddle.height / 2)
+
+    %{paddle | y: clamped_y}
   end
 end

--- a/apps/pong/test/pong/game/paddle_test.exs
+++ b/apps/pong/test/pong/game/paddle_test.exs
@@ -39,14 +39,24 @@ defmodule Pong.Game.PaddleTest do
       assert y < paddle.y
     end
 
-    test "prevents the paddle from overflowing off the game board" do
+    test "prevents the paddle from overflowing off the top of the game board" do
       board = build(:board)
-      # position the paddle center 1 point below the board edge
+      # position the paddle center 1 unit below the board edge
       paddle = build(:paddle, height: 100, y: board.height - 51)
 
       %{y: y} = Paddle.move(paddle, :up, board)
 
       assert y == board.height - 50
+    end
+
+    test "prevents the paddle from overflowing off the bottom of the game board" do
+      board = build(:board)
+      # position the paddle center 1 unit above the board edge
+      paddle = build(:paddle, height: 100, y: 51)
+
+      %{y: y} = Paddle.move(paddle, :down, board)
+
+      assert y == 50
     end
   end
 end


### PR DESCRIPTION
Why:

* We were only checking for the top limit of the board.

This change addresses the need by:

* Checking the bottom limit of the board.