### PR TITLE
Bump Elixir version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.7.1
+elixir 1.7.3
 erlang 20.3
 nodejs 10.10.0


### PR DESCRIPTION
Why:

* Our CI allows Elixir 1.7.3 by default.
* By using this version, we can greatly decrease the CI time since we
won't need to download 1.7.1 when first setting up the build.