### PR TITLE
Refactor movement into a specialized module

### DIFF
--- a/apps/pong/lib/pong/engine.ex
+++ b/apps/pong/lib/pong/engine.ex
@@ -1,7 +1,11 @@
 defmodule Pong.Engine do
   use GenServer
 
-  alias Pong.{Game, Renderer}
+  alias Pong.{
+    Game,
+    Movement,
+    Renderer
+  }
 
   import Pong.Config, only: [config: 3]
 
@@ -79,7 +83,7 @@ defmodule Pong.Engine do
   end
 
   def handle_info(:work, %{game: game} = state) do
-    new_state = %{state | game: Game.apply(game)}
+    new_state = %{state | game: Movement.apply_to(game)}
 
     schedule_work(new_state.period)
 

--- a/apps/pong/lib/pong/game.ex
+++ b/apps/pong/lib/pong/game.ex
@@ -6,7 +6,7 @@ defmodule Pong.Game do
     :paddle_right
   ]
 
-  alias __MODULE__
+  alias Pong.Movement
 
   alias Pong.Game.{
     Ball,
@@ -17,7 +17,7 @@ defmodule Pong.Game do
   @type t :: %__MODULE__{}
   @type player_ref :: :left | :right
 
-  @spec new :: Game.t()
+  @spec new :: t()
   def new do
     board = Board.new()
 
@@ -36,31 +36,15 @@ defmodule Pong.Game do
     }
   end
 
-  @doc """
-  Applies the ball movement to the game.
-  """
-  @spec apply(Game.t()) :: Game.t()
-  def apply(
-        %{
-          ball: ball,
-          board: board,
-          paddle_left: paddle_left,
-          paddle_right: paddle_right
-        } = game
-      ) do
-    %{game | ball: Ball.move(ball, board, paddle_left, paddle_right)}
-  end
-
-  @doc """
-  Applies movement to one of the paddles.
-  """
-  @spec move(Game.t(), player_ref(), Paddle.direction()) :: Game.t()
-  def move(game, player_ref, direction) do
+  # TODO: This will be moved to the apply cycle within Pong.Movement when we
+  # are able to buffer and fold similar actions between consecutive applies
+  @spec move(t(), player_ref(), Paddle.direction()) :: t()
+  def move(%__MODULE__{} = game, player_ref, direction) do
     paddle_ref = String.to_existing_atom("paddle_#{player_ref}")
 
     paddle =
       Map.get(game, paddle_ref)
-      |> Paddle.move(direction, game.board)
+      |> Movement.apply_to(direction, game.board)
 
     Map.put(game, paddle_ref, paddle)
   end

--- a/apps/pong/lib/pong/game/paddle.ex
+++ b/apps/pong/lib/pong/game/paddle.ex
@@ -15,10 +15,7 @@ defmodule Pong.Game.Paddle do
 
   @default_speed 5
 
-  alias __MODULE__
-  alias Pong.Game.Board
-
-  @spec new(keyword()) :: Paddle.t()
+  @spec new(keyword()) :: t()
   def new(args) do
     height = config!(__MODULE__, :height)
     margin = config!(__MODULE__, :margin)
@@ -44,13 +41,6 @@ defmodule Pong.Game.Paddle do
     }
   end
 
-  @spec move(Paddle.t(), Paddle.direction(), Board.t()) :: Paddle.t()
-  def move(paddle, direction, board) do
-    paddle
-    |> apply_vector(direction)
-    |> prevent_overflow(board)
-  end
-
   @spec random_fills(integer()) :: String.t()
   def random_fills(n) do
     config!(__MODULE__, :fills)
@@ -61,19 +51,20 @@ defmodule Pong.Game.Paddle do
   @spec random_fill :: String.t()
   def random_fill, do: random_fills(1) |> List.first()
 
-  defp apply_vector(%{y: y} = paddle, :up) do
-    %{paddle | y: y + @default_speed}
-  end
+  @spec apply_vector(t(), direction) :: t()
+  def apply_vector(%__MODULE__{y: y} = paddle, :up),
+    do: %{paddle | y: y + @default_speed}
 
-  defp apply_vector(%{y: y} = paddle, :down) do
-    %{paddle | y: y - @default_speed}
-  end
+  @spec apply_vector(t(), direction) :: t()
+  def apply_vector(%__MODULE__{y: y} = paddle, :down),
+    do: %{paddle | y: y - @default_speed}
 
-  defp prevent_overflow(paddle, board) do
+  @spec ensure_between(t(), integer(), integer()) :: t()
+  def ensure_between(%__MODULE__{} = paddle, min, max) do
     clamped_y =
       paddle.y
-      |> min(board.height - paddle.height / 2)
-      |> max(paddle.height / 2)
+      |> min(max - paddle.height / 2)
+      |> max(min + paddle.height / 2)
 
     %{paddle | y: clamped_y}
   end

--- a/apps/pong/lib/pong/movement.ex
+++ b/apps/pong/lib/pong/movement.ex
@@ -1,0 +1,101 @@
+defmodule Pong.Movement do
+  alias Pong.Game
+
+  alias Pong.Game.{
+    Ball,
+    Board,
+    Paddle
+  }
+
+  @doc """
+  Applies movement to one of the paddles.
+  """
+  @spec apply_to(Paddle.t(), Paddle.direction(), Board.t()) :: Paddle.t()
+  def apply_to(%Paddle{} = paddle, direction, %Board{} = board) do
+    paddle
+    |> Paddle.apply_vector(direction)
+    |> Paddle.ensure_between(0, board.height)
+  end
+
+  @doc """
+  Applies movement to the whole game.
+  """
+  @spec apply_to(Game.t()) :: Game.t()
+  def apply_to(%Game{} = game) do
+    %{
+      ball: ball,
+      board: board,
+      paddle_left: paddle_left,
+      paddle_right: paddle_right
+    } = game
+
+    moved_ball =
+      ball
+      |> apply_ball_movement(board)
+      |> apply_leftside_collision(paddle_left)
+      |> apply_rightside_collision(paddle_right)
+
+    %{game | ball: moved_ball}
+  end
+
+  defp apply_ball_movement(%Ball{} = ball, %Board{} = board) do
+    ball
+    |> Ball.apply_vector()
+    |> Ball.ensure_between_height(0, board.height)
+    |> Ball.ensure_between_width(0, board.width)
+    |> apply_board_collision(board)
+  end
+
+  defp apply_board_collision(ball, board) do
+    cond do
+      ball_in_board_height_limits?(ball, board) ->
+        Ball.reverse_vector_component(ball, :y)
+
+      ball_in_board_width_limits?(ball, board) ->
+        Ball.reverse_vector_component(ball, :x)
+
+      true ->
+        ball
+    end
+  end
+
+  defp apply_leftside_collision(ball, paddle) do
+    if ball_collided_leftside?(ball, paddle) do
+      Ball.reverse_vector_component(ball, :x)
+    else
+      ball
+    end
+  end
+
+  defp apply_rightside_collision(ball, paddle) do
+    if ball_collided_rightside?(ball, paddle) do
+      Ball.reverse_vector_component(ball, :x)
+    else
+      ball
+    end
+  end
+
+  defp ball_collided_leftside?(ball, paddle) do
+    ball.x - ball.radius <= paddle.x and ball.y <= paddle.y + paddle.height / 2 and
+      ball.y >= paddle.y - paddle.height / 2
+  end
+
+  defp ball_collided_rightside?(ball, paddle) do
+    ball.x + ball.radius >= paddle.x and ball.y <= paddle.y + paddle.height / 2 and
+      ball.y >= paddle.y - paddle.height / 2
+  end
+
+  defp ball_in_board_height_limits?(ball, board) do
+    upper_limit = ball.y + ball.radius
+    lower_limit = ball.y - ball.radius
+
+    upper_limit >= board.height or lower_limit <= 0
+  end
+
+  defp ball_in_board_width_limits?(ball, board) do
+    right_limit = ball.x + ball.radius
+    left_limit = ball.x - ball.radius
+
+    right_limit >= board.width or left_limit <= 0
+  end
+end

--- a/apps/pong/test/pong/game/ball_test.exs
+++ b/apps/pong/test/pong/game/ball_test.exs
@@ -51,82 +51,61 @@ defmodule Pong.Game.BallTest do
     end
   end
 
-  describe "move/4" do
-    test "updates the coordinates using the vector and the speed" do
-      board = build(:board)
-      ball = build(:ball, vector_x: 1, vector_y: -1, speed: 2)
-      paddle_left = build(:paddle)
-      paddle_right = build(:paddle)
+  describe "ensure_between_height/3" do
+    test "prevents the y coordinate from being over the max value" do
+      ball = build(:ball, y: 10, radius: 1)
 
-      %{x: x, y: y} = Ball.move(ball, board, paddle_left, paddle_right)
+      updated_ball = Ball.ensure_between_height(ball, 0, 5)
 
-      assert x == ball.x + 2
-      assert y == ball.y - 2
+      assert updated_ball.x == ball.x
+      # center is at max - radius
+      assert updated_ball.y == 4
     end
 
-    test "prevents the ball from overflowing off the game board" do
-      board = build(:board)
-      paddle_left = build(:paddle)
-      paddle_right = build(:paddle)
-      # all balls are 1 unit away from their respective wall
-      top_wall_ball =
-        build(:ball, radius: 5, y: board.height - 6, vector_y: 1, speed: 10)
+    test "prevents the y coordinate from being under the min value" do
+      ball = build(:ball, y: 10, radius: 1)
 
-      right_wall_ball =
-        build(:ball, radius: 5, x: board.width - 6, vector_x: 1, speed: 10)
+      updated_ball = Ball.ensure_between_height(ball, 20, 30)
 
-      bottom_wall_ball = build(:ball, radius: 5, y: 6, vector_y: -1, speed: 10)
-      left_wall_ball = build(:ball, radius: 5, x: 6, vector_x: -1, speed: 10)
+      assert updated_ball.x == ball.x
+      # center is at min - radius
+      assert updated_ball.y == 21
+    end
+  end
 
-      %{y: top_wall_ball_y} =
-        Ball.move(top_wall_ball, board, paddle_left, paddle_right)
+  describe "ensure_between_width/3" do
+    test "prevents the x coordinate from being over the max value" do
+      ball = build(:ball, x: 10, radius: 1)
 
-      %{x: right_wall_ball_x} =
-        Ball.move(right_wall_ball, board, paddle_left, paddle_right)
+      updated_ball = Ball.ensure_between_width(ball, 0, 5)
 
-      %{y: bottom_wall_ball_y} =
-        Ball.move(bottom_wall_ball, board, paddle_left, paddle_right)
-
-      %{x: left_wall_ball_x} =
-        Ball.move(left_wall_ball, board, paddle_left, paddle_right)
-
-      assert top_wall_ball_y == board.height - top_wall_ball.radius
-      assert right_wall_ball_x == board.height - right_wall_ball.radius
-      assert bottom_wall_ball_y == bottom_wall_ball.radius
-      assert left_wall_ball_x == left_wall_ball.radius
+      assert updated_ball.y == ball.y
+      # center is at max - radius
+      assert updated_ball.x == 4
     end
 
-    test "updates the vector when colliding with the wall" do
-      board = build(:board)
-      paddle_left = build(:paddle, x: 30, y: 0)
-      paddle_right = build(:paddle, x: 970, y: 0)
+    test "prevents the x coordinate from being under the min value" do
+      ball = build(:ball, x: 10, radius: 1)
 
-      # all balls are 1 unit away from their respective wall
-      top_wall_ball =
-        build(:ball, radius: 5, y: board.height - 6, vector_y: 1, speed: 10)
+      updated_ball = Ball.ensure_between_width(ball, 20, 30)
 
-      right_wall_ball =
-        build(:ball, radius: 5, x: board.width - 6, vector_x: 1, speed: 10)
+      assert updated_ball.y == ball.y
+      # center is at min - radius
+      assert updated_ball.x == 21
+    end
+  end
 
-      bottom_wall_ball = build(:ball, radius: 5, y: 6, vector_y: -1, speed: 10)
-      left_wall_ball = build(:ball, radius: 5, x: 6, vector_x: -1, speed: 10)
+  describe "reverse_vector_component/2" do
+    test "reverses the corresponding vector component" do
+      ball = build(:ball, vector_x: 1, vector_y: 1)
 
-      %{vector_y: top_wall_vector_y} =
-        Ball.move(top_wall_ball, board, paddle_left, paddle_right)
+      updated_ball =
+        ball
+        |> Ball.reverse_vector_component(:x)
+        |> Ball.reverse_vector_component(:y)
 
-      %{vector_x: right_wall_vector_x} =
-        Ball.move(right_wall_ball, board, paddle_left, paddle_right)
-
-      %{vector_y: bottom_wall_vector_y} =
-        Ball.move(bottom_wall_ball, board, paddle_left, paddle_right)
-
-      %{vector_x: left_wall_vector_x} =
-        Ball.move(left_wall_ball, board, paddle_left, paddle_right)
-
-      assert top_wall_vector_y == -top_wall_ball.vector_y
-      assert right_wall_vector_x == -right_wall_ball.vector_x
-      assert bottom_wall_vector_y == -bottom_wall_ball.vector_y
-      assert left_wall_vector_x == -left_wall_ball.vector_x
+      assert updated_ball.vector_x == -ball.vector_x
+      assert updated_ball.vector_y == -ball.vector_y
     end
   end
 end

--- a/apps/pong/test/pong/game/paddle_test.exs
+++ b/apps/pong/test/pong/game/paddle_test.exs
@@ -20,43 +20,45 @@ defmodule Pong.Game.PaddleTest do
     end
   end
 
-  describe "move/3" do
-    test "increments the y coordinate if moving up" do
+  describe "apply_vector/1" do
+    test "uses a positive vector when moving up" do
       paddle = build(:paddle)
-      board = build(:board)
 
-      %{y: y} = Paddle.move(paddle, :up, board)
+      updated_paddle = Paddle.apply_vector(paddle, :up)
 
-      assert y > paddle.y
+      assert updated_paddle.x == paddle.x
+      assert updated_paddle.y == paddle.y + 5
     end
 
-    test "decrements the y coordinate if moving down" do
+    test "uses a negative vector when moving down" do
       paddle = build(:paddle)
-      board = build(:board)
 
-      %{y: y} = Paddle.move(paddle, :down, board)
+      updated_paddle = Paddle.apply_vector(paddle, :down)
 
-      assert y < paddle.y
+      assert updated_paddle.x == paddle.x
+      assert updated_paddle.y == paddle.y - 5
+    end
+  end
+
+  describe "ensure_between/3" do
+    test "prevents the y coordinate from being over the max value" do
+      paddle = build(:paddle, y: 10, height: 2)
+
+      updated_paddle = Paddle.ensure_between(paddle, 0, 5)
+
+      assert updated_paddle.x == paddle.x
+      # center is at max - height / 2
+      assert updated_paddle.y == 4
     end
 
-    test "prevents the paddle from overflowing off the top of the game board" do
-      board = build(:board)
-      # position the paddle center 1 unit below the board edge
-      paddle = build(:paddle, height: 100, y: board.height - 51)
+    test "prevents the y coordinate from being under the min value" do
+      paddle = build(:paddle, y: 10, height: 2)
 
-      %{y: y} = Paddle.move(paddle, :up, board)
+      updated_paddle = Paddle.ensure_between(paddle, 20, 30)
 
-      assert y == board.height - 50
-    end
-
-    test "prevents the paddle from overflowing off the bottom of the game board" do
-      board = build(:board)
-      # position the paddle center 1 unit above the board edge
-      paddle = build(:paddle, height: 100, y: 51)
-
-      %{y: y} = Paddle.move(paddle, :down, board)
-
-      assert y == 50
+      assert updated_paddle.x == paddle.x
+      # center is at min - height / 2
+      assert updated_paddle.y == 21
     end
   end
 end

--- a/apps/pong/test/pong/movement_test.exs
+++ b/apps/pong/test/pong/movement_test.exs
@@ -1,0 +1,177 @@
+defmodule Pong.MovementTest do
+  use ExUnit.Case
+  doctest Pong.Movement
+
+  alias Pong.{Game, Movement}
+
+  alias Pong.Game.{
+    Ball,
+    Paddle
+  }
+
+  import Pong.Factory
+
+  describe "apply_to/3" do
+    test "increments the y coordinate if moving up" do
+      paddle = build(:paddle)
+      board = build(:board)
+
+      %Paddle{y: y} = Movement.apply_to(paddle, :up, board)
+
+      assert y > paddle.y
+    end
+
+    test "decrements the y coordinate if moving down" do
+      paddle = build(:paddle)
+      board = build(:board)
+
+      %Paddle{y: y} = Movement.apply_to(paddle, :down, board)
+
+      assert y < paddle.y
+    end
+
+    test "prevents the paddle from overflowing off the top of the game board" do
+      board = build(:board)
+      # position the paddle center 1 unit below the board edge
+      paddle = build(:paddle, height: 100, y: board.height - 51)
+
+      %Paddle{y: y} = Movement.apply_to(paddle, :up, board)
+
+      assert y == board.height - 50
+    end
+
+    test "prevents the paddle from overflowing off the bottom of the game board" do
+      board = build(:board)
+      # position the paddle center 1 unit above the board edge
+      paddle = build(:paddle, height: 100, y: 51)
+
+      %Paddle{y: y} = Movement.apply_to(paddle, :down, board)
+
+      assert y == 50
+    end
+  end
+
+  describe "apply_to/1" do
+    test "updates the ball coordinates using the vector and the speed" do
+      ball = build(:ball, vector_x: 1, vector_y: -1, speed: 2)
+      game = build(:game, ball: ball)
+
+      %Game{ball: %Ball{x: x, y: y}} = Movement.apply_to(game)
+
+      assert x == ball.x + 2
+      assert y == ball.y - 2
+    end
+
+    test "prevents the ball from overflowing off the game board" do
+      board = build(:board)
+
+      # all balls are 1 unit away from their respective wall
+      top_wall_ball =
+        build(:ball, radius: 5, y: board.height - 6, vector_y: 1, speed: 10)
+
+      right_wall_ball =
+        build(:ball, radius: 5, x: board.width - 6, vector_x: 1, speed: 10)
+
+      bottom_wall_ball = build(:ball, radius: 5, y: 6, vector_y: -1, speed: 10)
+      left_wall_ball = build(:ball, radius: 5, x: 6, vector_x: -1, speed: 10)
+
+      game = build(:game, board: board)
+
+      %Game{ball: %Ball{y: top_wall_ball_y}} =
+        Movement.apply_to(%{game | ball: top_wall_ball})
+
+      %Game{ball: %Ball{x: right_wall_ball_x}} =
+        Movement.apply_to(%{game | ball: right_wall_ball})
+
+      %Game{ball: %Ball{y: bottom_wall_ball_y}} =
+        Movement.apply_to(%{game | ball: bottom_wall_ball})
+
+      %Game{ball: %Ball{x: left_wall_ball_x}} =
+        Movement.apply_to(%{game | ball: left_wall_ball})
+
+      assert top_wall_ball_y == board.height - top_wall_ball.radius
+      assert right_wall_ball_x == board.height - right_wall_ball.radius
+      assert bottom_wall_ball_y == bottom_wall_ball.radius
+      assert left_wall_ball_x == left_wall_ball.radius
+    end
+
+    test "updates the ball vector when colliding with the wall" do
+      board = build(:board)
+      # move the paddles out of the way
+      paddle = build(:paddle, x: -100, y: -100)
+
+      # all balls are 1 unit away from their respective wall
+      top_wall_ball =
+        build(:ball, radius: 5, y: board.height - 6, vector_y: 1, speed: 10)
+
+      right_wall_ball =
+        build(:ball, radius: 5, x: board.width - 6, vector_x: 1, speed: 10)
+
+      bottom_wall_ball = build(:ball, radius: 5, y: 6, vector_y: -1, speed: 10)
+      left_wall_ball = build(:ball, radius: 5, x: 6, vector_x: -1, speed: 10)
+
+      game =
+        build(:game, board: board, paddle_left: paddle, paddle_right: paddle)
+
+      %Game{ball: %Ball{vector_y: top_wall_vector_y}} =
+        Movement.apply_to(%{game | ball: top_wall_ball})
+
+      %Game{ball: %Ball{vector_x: right_wall_vector_x}} =
+        Movement.apply_to(%{game | ball: right_wall_ball})
+
+      %Game{ball: %Ball{vector_y: bottom_wall_vector_y}} =
+        Movement.apply_to(%{game | ball: bottom_wall_ball})
+
+      %Game{ball: %Ball{vector_x: left_wall_vector_x}} =
+        Movement.apply_to(%{game | ball: left_wall_ball})
+
+      assert top_wall_vector_y == -top_wall_ball.vector_y
+      assert right_wall_vector_x == -right_wall_ball.vector_x
+      assert bottom_wall_vector_y == -bottom_wall_ball.vector_y
+      assert left_wall_vector_x == -left_wall_ball.vector_x
+    end
+
+    test "updates the vector when colliding with the paddles" do
+      board = build(:board)
+      left_paddle = build(:paddle, x: 30, y: board.height / 2)
+      right_paddle = build(:paddle, x: board.width - 30, y: board.height / 2)
+
+      # bothh balls are 1 unit away from their respective paddle
+      leftside_ball =
+        build(:ball,
+          radius: 5,
+          y: board.height / 2,
+          x: 36,
+          vector_x: -1,
+          vector_y: 0,
+          speed: 10
+        )
+
+      rightside_ball =
+        build(:ball,
+          radius: 5,
+          y: board.height / 2,
+          x: board.width - 36,
+          vector_x: 1,
+          vector_y: 0,
+          speed: 10
+        )
+
+      game =
+        build(:game,
+          board: board,
+          paddle_left: left_paddle,
+          paddle_right: right_paddle
+        )
+
+      %Game{ball: updated_leftside_ball} =
+        Movement.apply_to(%{game | ball: leftside_ball})
+
+      %Game{ball: updated_rightside_ball} =
+        Movement.apply_to(%{game | ball: rightside_ball})
+
+      assert updated_leftside_ball.vector_x == -leftside_ball.vector_x
+      assert updated_rightside_ball.vector_x == -rightside_ball.vector_x
+    end
+  end
+end


### PR DESCRIPTION
Why:

* Currently movement is split between the Ball and the Game modules.
* Each need to be aware of the structure of the other and of the Board
and Paddle modules.
* Besides leaking internal knowledge, having the movement split between
different modules doesn't allow us to buffer movement actions that occur
between two consecutive apply cycles.

This change addresses the need by:

* Moving all logic related to movement to a single separate
Pong.Movement module.