### PR TITLE
Add metadata topics

### DIFF
--- a/apps/client/lib/client_web/pong_subscription.ex
+++ b/apps/client/lib/client_web/pong_subscription.ex
@@ -1,9 +1,13 @@
 defmodule ClientWeb.PongSubscription do
   def create do
-    Pong.subscribe(&broadcast_data/1)
+    Pong.subscribe(&broadcast/1)
   end
 
-  defp broadcast_data(data) do
+  defp broadcast({"data", data}) do
     ClientWeb.Endpoint.broadcast("game:board", "data", data)
+  end
+
+  defp broadcast({event, data}) do
+    ClientWeb.Endpoint.broadcast("game:board", event, data)
   end
 end

--- a/apps/client/test/integration/game_test.exs
+++ b/apps/client/test/integration/game_test.exs
@@ -18,6 +18,10 @@ defmodule Client.GameTest do
     test "updates watchers on every move" do
       initial_state = Pong.Engine.state()
 
+      {:ok, _, _game_socket} =
+        socket()
+        |> subscribe_and_join(GameChannel, "game:board")
+
       {:ok, _, controller_socket} =
         socket()
         |> subscribe_and_join(GameChannel, "game:play")
@@ -26,15 +30,21 @@ defmodule Client.GameTest do
         socket()
         |> subscribe_and_join(GameChannel, "game:play")
 
-      {:ok, _, _game_socket} =
-        socket()
-        |> subscribe_and_join(GameChannel, "game:board")
+      assert_broadcast("dimensions", %{
+        "board" => [_, _],
+        "ball" => _,
+        "paddle" => [_, _]
+      })
 
       push(controller_socket, "player:move", %{"direction" => "up"})
 
-      assert_broadcast("data", data)
+      assert_broadcast("data", %{
+        "ball" => [_, _],
+        "paddle_left" => [_, paddle_left_y],
+        "paddle_right" => [_, _]
+      })
 
-      assert data.game.paddle_left.y > initial_state.game.paddle_left.y
+      assert paddle_left_y > initial_state.game.paddle_left.y
     end
   end
 end

--- a/apps/pong/lib/pong/engine.ex
+++ b/apps/pong/lib/pong/engine.ex
@@ -121,7 +121,8 @@ defmodule Pong.Engine do
   defp players_ready?(state), do: state.player_left && state.player_right
 
   defp start_game(state) do
-    Renderer.start()
+    Renderer.start(state.game)
+
     schedule_work(state.period)
   end
 

--- a/apps/pong/test/pong/engine_test.exs
+++ b/apps/pong/test/pong/engine_test.exs
@@ -55,7 +55,7 @@ defmodule Pong.EngineTest do
     end
 
     test "adds the right player if there is a left player" do
-      with_mock Renderer, start: fn -> :ok end do
+      with_mock Renderer, start: fn _ -> :ok end do
         state = build_pong_state(player_left: true)
         {:reply, _, new_state} = Engine.handle_call(:join, self(), state)
 
@@ -64,16 +64,16 @@ defmodule Pong.EngineTest do
     end
 
     test "starts the renderer" do
-      with_mock Renderer, start: fn -> :ok end do
+      with_mock Renderer, start: fn _ -> :ok end do
         state = build_pong_state(player_left: true)
         {:reply, _, _} = Engine.handle_call(:join, self(), state)
 
-        assert called(Renderer.start())
+        assert called(Renderer.start(state.game))
       end
     end
 
     test "schedules work if all players are ready" do
-      with_mock Renderer, start: fn -> :ok end do
+      with_mock Renderer, start: fn _ -> :ok end do
         state = build_pong_state(player_left: true, period: 1)
         {:reply, _, _} = Engine.handle_call(:join, self(), state)
 


### PR DESCRIPTION
Why:

* We want to parse the render and the game events as asynchronously as
possible.
* We also want to pre-compute the ratios and the dimensions of the board
to avoid doing so in each data event received.
* The extra payload to carry the game object dimensions is also a waste
of space and network time.

This change addresses the need by:

* Separating metadata topics in the game:board channel.
* Broadcasting the game elements dimensions when the game starts.
* Broadcasting only the positions of the different game dimensions when
there a work cycle is processed.

NOTE:

* These are breaking changes. __DO NOT MERGE YET__. Only do so after the
frontend has been updated to reflect these changes.