### PR TITLE
Fix game speed

### DIFF
--- a/apps/pong/config/config.exs
+++ b/apps/pong/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :pong, Pong,
-  fps: 30,
+  fps: 60,
   start_delay: 3_000
 
 config :pong, Pong.Game.Board,

--- a/apps/pong/lib/pong/game/ball.ex
+++ b/apps/pong/lib/pong/game/ball.ex
@@ -8,7 +8,7 @@ defmodule Pong.Game.Ball do
     :speed
   ]
 
-  @default_speed 5
+  @default_speed 2
   @min_vector_value 4
   @max_vector_value 8
 


### PR DESCRIPTION
Why:

* We are rendering a few times due to the high ball speed.

This change addresses the need by:

* Decreasing the ball speed but increasing the amount of times we
render.