### PR TITLE
Wait for any pending cycles when joining or starting the game

### DIFF
--- a/apps/pong/lib/pong/engine.ex
+++ b/apps/pong/lib/pong/engine.ex
@@ -50,6 +50,8 @@ defmodule Pong.Engine do
   end
 
   def handle_call(:join, _from, state) do
+    wait_for_next_cycle(state.period + 100)
+
     case add_player(state) do
       {:ok, player_data, new_state} ->
         if players_ready?(new_state), do: prepare_start(state)

--- a/apps/pong/lib/pong/renderer.ex
+++ b/apps/pong/lib/pong/renderer.ex
@@ -36,6 +36,8 @@ defmodule Pong.Renderer do
   end
 
   def handle_cast({:start, game, delay}, state) do
+    wait_for_next_render(state.period + 100)
+
     broadcast(
       state.subscriptions,
       {"game_starting", %{"delay" => delay, "game" => game}}


### PR DESCRIPTION
Why:

* Sometimes we are having the light speed bug again.
* It probably is due a join event being processed before the leave
event.

This change addresses the need by:

* Waiting for a pending work event before adding the player or starting
the game.