### PR TITLE
Add events to the pong game

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -45,7 +45,7 @@
         # Refactor
 
         {Credo.Check.Refactor.ABCSize, exit_status: 0},
-        {Credo.Check.Refactor.AppendSingleItem},
+        {Credo.Check.Refactor.AppendSingleItem, false},
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements, false},
         {Credo.Check.Refactor.CyclomaticComplexity},

--- a/apps/client/test/integration/game_test.exs
+++ b/apps/client/test/integration/game_test.exs
@@ -16,7 +16,7 @@ defmodule Client.GameTest do
 
   describe "gameplay" do
     test "updates watchers on every move" do
-      initial_state = Pong.Engine.state()
+      {initial_state, []} = Pong.Engine.consume()
 
       {:ok, _, _game_socket} =
         socket()

--- a/apps/pong/lib/pong/renderer.ex
+++ b/apps/pong/lib/pong/renderer.ex
@@ -65,8 +65,10 @@ defmodule Pong.Renderer do
   end
 
   def handle_info(:work, state) do
-    game = Pong.Engine.state()
+    {game, events} = Pong.Engine.consume()
+
     broadcast(state.subscriptions, {"data", game})
+    for event <- events, do: broadcast(state.subscriptions, event)
 
     schedule_work(state.period)
 

--- a/apps/pong/test/pong/renderer_test.exs
+++ b/apps/pong/test/pong/renderer_test.exs
@@ -97,13 +97,24 @@ defmodule Pong.RendererTest do
 
   describe "handle_info/2 for :work messages" do
     test "broadcasts the game state to all subscriptions" do
-      with_mock Pong.Engine, state: fn -> :ok end do
+      with_mock Pong.Engine, consume: fn -> {:ok, []} end do
         subscriptions = [fn data -> send self(), data end]
         state = build_state(subscriptions: subscriptions)
 
         {:noreply, _} = Renderer.handle_info(:work, state)
 
         assert_receive {"data", :ok}
+      end
+    end
+
+    test "broadcasts the events to all subscriptions" do
+      with_mock Pong.Engine, consume: fn -> {:ok, [{"player_left", :right}]} end do
+        subscriptions = [fn data -> send self(), data end]
+        state = build_state(subscriptions: subscriptions)
+
+        {:noreply, _} = Renderer.handle_info(:work, state)
+
+        assert_receive {"player_left", :right}
       end
     end
   end


### PR DESCRIPTION
Why:

* We want to be notified in the metadata channel when an event occurs (a
point, a player leaves, etc).

This change addresses the need by:

* Adding the concept of events to the engine and renderer.
* Broadcasting those events through the metadata channel.
* Emitting an event when the player leaves.