### PR TITLE
Refactor Engine to allow multiple versions.

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -51,7 +51,7 @@
         {Credo.Check.Refactor.CyclomaticComplexity},
         # This should be a product of our common sense and detailed in reviews
         {Credo.Check.Refactor.FunctionArity, false},
-        {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.LongQuoteBlocks, false},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},

--- a/apps/client/test/integration/game_test.exs
+++ b/apps/client/test/integration/game_test.exs
@@ -4,7 +4,7 @@ defmodule Client.GameTest do
   alias ClientWeb.Channels.GameChannel
 
   setup do
-    with {:ok, _} <- Pong.Engine.start_link([]),
+    with {:ok, _} <- Pong.Engines.Singles.start_link([]),
          {:ok, _} <- Pong.Renderer.start_link([]) do
       ClientWeb.PongSubscription.create()
 
@@ -16,7 +16,7 @@ defmodule Client.GameTest do
 
   describe "gameplay" do
     test "updates watchers on every move" do
-      {initial_state, []} = Pong.Engine.consume()
+      {initial_state, []} = Pong.Engines.Singles.consume()
 
       {:ok, _, _game_socket} =
         socket()

--- a/apps/pong/lib/application.ex
+++ b/apps/pong/lib/application.ex
@@ -8,5 +8,5 @@ defmodule Pong.Application do
   end
 
   defp children(:test), do: []
-  defp children(_), do: [Pong.Engine, Pong.Renderer]
+  defp children(_), do: [Pong.Engines.Singles, Pong.Renderer]
 end

--- a/apps/pong/lib/pong.ex
+++ b/apps/pong/lib/pong.ex
@@ -1,8 +1,8 @@
 defmodule Pong do
   defdelegate subscribe(fun), to: Pong.Renderer
   defdelegate current_state, to: Pong.Renderer
-  defdelegate join, to: Pong.Engine
-  defdelegate leave(player_id), to: Pong.Engine
-  defdelegate stop, to: Pong.Engine
-  defdelegate move(player, direction), to: Pong.Engine
+  defdelegate join, to: Pong.Engines.Singles
+  defdelegate leave(player_id), to: Pong.Engines.Singles
+  defdelegate stop, to: Pong.Engines.Singles
+  defdelegate move(player, direction), to: Pong.Engines.Singles
 end

--- a/apps/pong/lib/pong/engines/singles.ex
+++ b/apps/pong/lib/pong/engines/singles.ex
@@ -1,0 +1,13 @@
+defmodule Pong.Engines.Singles do
+  use Pong.Engine
+
+  def add_player(nil, _), do: {:ok, :left, true}
+  def add_player(_, nil), do: {:ok, :right, true}
+  def add_player(_, _), do: {:error, :game_full}
+
+  def remove_player(:left, true), do: {:ok, nil}
+  def remove_player(:right, true), do: {:ok, nil}
+  def remove_player(_, _), do: {:error, :invalid_player}
+
+  def players_ready?(left, right), do: left && right
+end

--- a/apps/pong/lib/pong/game.ex
+++ b/apps/pong/lib/pong/game.ex
@@ -25,6 +25,7 @@ defmodule Pong.Game do
           score_left: integer(),
           score_right: integer()
         }
+
   @type default :: %__MODULE__{
           ball: Ball.t(),
           board: Board.t(),

--- a/apps/pong/lib/pong/renderer.ex
+++ b/apps/pong/lib/pong/renderer.ex
@@ -65,7 +65,7 @@ defmodule Pong.Renderer do
   end
 
   def handle_info(:work, state) do
-    {game, events} = Pong.Engine.consume()
+    {game, events} = Pong.Engines.Singles.consume()
 
     broadcast(state.subscriptions, {"data", game})
     for event <- events, do: broadcast(state.subscriptions, event)

--- a/apps/pong/test/pong/engine_test.exs
+++ b/apps/pong/test/pong/engine_test.exs
@@ -3,10 +3,11 @@ defmodule Pong.EngineTest do
   doctest Pong.Engine
 
   alias Pong.{
-    Engine,
     Movement,
     Renderer
   }
+
+  alias Pong.TestEngine, as: Engine
 
   import Pong.Factory
   import Mock
@@ -39,32 +40,6 @@ defmodule Pong.EngineTest do
   end
 
   describe "handle_call/3 for :join messages" do
-    test "errors if the game is full" do
-      state = build_pong_state(player_left: true, player_right: true)
-
-      {:reply, error, _} = Engine.handle_call(:join, self(), state)
-
-      assert {:error, :game_full} == error
-    end
-
-    test "adds the left player if no players have joined" do
-      state = build_pong_state()
-
-      {:reply, _, new_state} = Engine.handle_call(:join, self(), state)
-
-      assert new_state[:player_left]
-    end
-
-    test "adds the right player if there is a left player" do
-      with_mock Renderer, start: fn _, _ -> :ok end do
-        state = build_pong_state(player_left: true)
-
-        {:reply, _, new_state} = Engine.handle_call(:join, self(), state)
-
-        assert new_state[:player_right]
-      end
-    end
-
     test "starts the renderer" do
       with_mock Renderer, start: fn _, _ -> :ok end do
         state = build_pong_state(player_left: true)
@@ -106,25 +81,6 @@ defmodule Pong.EngineTest do
   end
 
   describe "handle_call/3 for :leave messages" do
-    test "removes the correct player from the state" do
-      state = build_pong_state(player_right: true)
-
-      {:reply, :ok, new_state} =
-        Engine.handle_call({:leave, :right}, self(), state)
-
-      refute new_state[:player_right]
-    end
-
-    test "ignores changes if the player id is invalid" do
-      state = build_pong_state(player_right: true, player_left: true)
-
-      assert {:reply, :ok, new_state} =
-               Engine.handle_call({:leave, :fake_id}, self(), state)
-
-      assert new_state.player_left
-      assert new_state.player_right
-    end
-
     test "adds an event if a player leaves" do
       state = build_pong_state(player_right: true, player_left: true)
 

--- a/apps/pong/test/pong/engines/singles_test.exs
+++ b/apps/pong/test/pong/engines/singles_test.exs
@@ -1,0 +1,42 @@
+defmodule Pong.Engines.SinglesTest do
+  use ExUnit.Case
+  doctest Pong.Engines.Singles
+
+  alias Pong.Engines.Singles
+
+  describe "add_player/1" do
+    test "errors if the game is full" do
+      assert {:error, :game_full} = Singles.add_player(true, true)
+    end
+
+    test "adds the left player if no players have joined" do
+      assert {:ok, :left, true} = Singles.add_player(nil, nil)
+    end
+
+    test "adds the right player if there is a left player" do
+      assert {:ok, :right, true} = Singles.add_player(true, nil)
+    end
+  end
+
+  describe "remove_player/2" do
+    test "removes the player if it has joined" do
+      assert {:ok, nil} = Singles.remove_player(:left, true)
+      assert {:ok, nil} = Singles.remove_player(:right, true)
+    end
+
+    test "errors if the player hasn't joined" do
+      assert {:error, :invalid_player} = Singles.remove_player(:left, nil)
+    end
+  end
+
+  describe "players_ready?/0" do
+    test "is true if there are two players" do
+      assert Singles.players_ready?(true, true)
+    end
+
+    test "is false if there are less than two players" do
+      refute Singles.players_ready?(true, nil)
+      refute Singles.players_ready?(nil, true)
+    end
+  end
+end

--- a/apps/pong/test/pong/renderer_test.exs
+++ b/apps/pong/test/pong/renderer_test.exs
@@ -2,6 +2,7 @@ defmodule Pong.RendererTest do
   use ExUnit.Case
   doctest Pong.Renderer
 
+  alias Pong.Engines.Singles, as: Engine
   alias Pong.Renderer
 
   import Pong.Factory
@@ -97,7 +98,7 @@ defmodule Pong.RendererTest do
 
   describe "handle_info/2 for :work messages" do
     test "broadcasts the game state to all subscriptions" do
-      with_mock Pong.Engine, consume: fn -> {:ok, []} end do
+      with_mock Engine, consume: fn -> {:ok, []} end do
         subscriptions = [fn data -> send self(), data end]
         state = build_state(subscriptions: subscriptions)
 
@@ -108,7 +109,7 @@ defmodule Pong.RendererTest do
     end
 
     test "broadcasts the events to all subscriptions" do
-      with_mock Pong.Engine, consume: fn -> {:ok, [{"player_left", :right}]} end do
+      with_mock Engine, consume: fn -> {:ok, [{"player_left", :right}]} end do
         subscriptions = [fn data -> send self(), data end]
         state = build_state(subscriptions: subscriptions)
 
@@ -119,7 +120,7 @@ defmodule Pong.RendererTest do
     end
 
     test "schedules work" do
-      with_mock Pong.Engine, consume: fn -> {:ok, []} end do
+      with_mock Engine, consume: fn -> {:ok, []} end do
         subscriptions = [fn data -> send self(), data end]
         state = build_state(subscriptions: subscriptions, period: 1)
 
@@ -130,7 +131,7 @@ defmodule Pong.RendererTest do
     end
 
     test "doesn't schedule work if the game is over" do
-      with_mock Pong.Engine, consume: fn -> {:ok, [{"game_over", %{}}]} end do
+      with_mock Engine, consume: fn -> {:ok, [{"game_over", %{}}]} end do
         subscriptions = [fn data -> send self(), data end]
         state = build_state(subscriptions: subscriptions, period: 1)
 

--- a/apps/pong/test/support/test_engine.ex
+++ b/apps/pong/test/support/test_engine.ex
@@ -1,0 +1,7 @@
+defmodule Pong.TestEngine do
+  use Pong.Engine
+
+  defdelegate add_player(left, right), to: Pong.Engines.Singles
+  defdelegate remove_player(player_ref, player), to: Pong.Engines.Singles
+  defdelegate players_ready?(left, right), to: Pong.Engines.Singles
+end


### PR DESCRIPTION
Why:

* We want to allow different versions of the game.

This change addresses the need by:

* Refactoring Engine to use metaprogramming™.
* Implement the previous Engine behavior as Engines.Singles.