### PR TITLE
Fix background delay on the controller page

### DIFF
--- a/apps/client/frontend/components/GameRoom/index.js
+++ b/apps/client/frontend/components/GameRoom/index.js
@@ -20,7 +20,13 @@ export default class GameRoom extends Component {
     this.playChannel = new Channel('game:play');
     this.metadataChannel = new Channel('game:metadata');
 
-    this.joinChannel(this.playChannel);
+    this.joinChannel(this.playChannel).then(response => {
+      this.setState({
+        loading: false,
+        status: 'joined',
+        paddleColor: response.paddle_color,
+      });
+    });
     this.joinChannel(this.metadataChannel);
 
     this.subscribeToGameOver();
@@ -37,11 +43,7 @@ export default class GameRoom extends Component {
 
       console.log('Joined successfully', response); // eslint-disable-line
 
-      this.setState({
-        loading: false,
-        status: 'joined',
-        paddleColor: response.paddle_color,
-      });
+      return response;
     } catch (error) {
       console.log('Unable to join', error); // eslint-disable-line
 
@@ -80,7 +82,7 @@ export default class GameRoom extends Component {
   render() {
     const { loading, gameOver } = this.state;
 
-    if (loading) return <div styleName="root" />;
+    if (loading) return null;
 
     if (gameOver) return <Centered>Game Over!</Centered>;
 


### PR DESCRIPTION
When entering the controller the content would be rendered without the actual controller background, because of an error on the reusable `joinChannel` function.