### PR TITLE
Add the multiplayer engine.

### DIFF
--- a/apps/client/frontend/components/BoardRoom/index.js
+++ b/apps/client/frontend/components/BoardRoom/index.js
@@ -32,8 +32,7 @@ export default class BoardRoom extends Component {
 
       this.subscribeToMetadata();
 
-
-      if (response.game) {
+      if (response.game && !this.noPlayersAvailable(response)) {
         this.setState({ game: response.game });
       }
     } catch (error) {
@@ -50,8 +49,10 @@ export default class BoardRoom extends Component {
       this.setState({ gameOver: true });
     });
 
-    this.channel.on('player_left', () => {
-      this.setState({ delay: null, game: null });
+    this.channel.on('player_left', data => {
+      if (this.noPlayersAvailable(data)) {
+        this.setState({ delay: null, game: null });
+      }
     });
   };
 
@@ -65,15 +66,20 @@ export default class BoardRoom extends Component {
     }
   };
 
+  noPlayersAvailable = ({
+    player_left: playerLeft,
+    player_right: playerRight,
+  }) =>
+    _.isNil(playerLeft) ||
+    _.isNil(playerRight) ||
+    playerLeft === 0 ||
+    playerRight === 0;
+
   render() {
     const { game, delay, gameOver } = this.state;
 
     if (gameOver) {
-      return (
-        <Centered>
-          Game Over!
-        </Centered>
-      );
+      return <Centered>Game Over!</Centered>;
     }
 
     if (_.isNil(game)) {

--- a/apps/client/test/integration/game_test.exs
+++ b/apps/client/test/integration/game_test.exs
@@ -4,7 +4,7 @@ defmodule Client.GameTest do
   alias ClientWeb.Channels.GameChannel
 
   setup do
-    with {:ok, _} <- Pong.Engines.Singles.start_link([]),
+    with {:ok, _} <- Pong.Engines.Multi.start_link([]),
          {:ok, _} <- Pong.Renderer.start_link([]) do
       ClientWeb.PongSubscription.create()
 
@@ -16,7 +16,7 @@ defmodule Client.GameTest do
 
   describe "gameplay" do
     test "updates watchers on every move" do
-      {initial_state, []} = Pong.Engines.Singles.consume()
+      {initial_state, []} = Pong.Engines.Multi.consume()
 
       {:ok, _, _game_socket} =
         socket()

--- a/apps/pong/lib/application.ex
+++ b/apps/pong/lib/application.ex
@@ -8,5 +8,5 @@ defmodule Pong.Application do
   end
 
   defp children(:test), do: []
-  defp children(_), do: [Pong.Engines.Singles, Pong.Renderer]
+  defp children(_), do: [Pong.Engines.Multi, Pong.Renderer]
 end

--- a/apps/pong/lib/pong.ex
+++ b/apps/pong/lib/pong.ex
@@ -1,8 +1,8 @@
 defmodule Pong do
   defdelegate subscribe(fun), to: Pong.Renderer
   defdelegate current_state, to: Pong.Renderer
-  defdelegate join, to: Pong.Engines.Singles
-  defdelegate leave(player_id), to: Pong.Engines.Singles
-  defdelegate stop, to: Pong.Engines.Singles
-  defdelegate move(player, direction), to: Pong.Engines.Singles
+  defdelegate join, to: Pong.Engines.Multi
+  defdelegate leave(player_id), to: Pong.Engines.Multi
+  defdelegate stop, to: Pong.Engines.Multi
+  defdelegate move(player, direction), to: Pong.Engines.Multi
 end

--- a/apps/pong/lib/pong/engines/multi.ex
+++ b/apps/pong/lib/pong/engines/multi.ex
@@ -1,0 +1,35 @@
+defmodule Pong.Engines.Multi do
+  use Pong.Engine
+
+  def add_player(nil, _), do: {:ok, :left, 1}
+  def add_player(_, nil), do: {:ok, :right, 1}
+
+  def add_player(left, right)
+      when left > 200 or right > 200,
+      do: {:error, :game_full}
+
+  def add_player(left, right)
+      when left <= right,
+      do: {:ok, :left, left + 1}
+
+  def add_player(left, right)
+      when right < left,
+      do: {:ok, :right, right + 1}
+
+  def remove_player(_, nil),
+    do: {:error, :invalid_player}
+
+  def remove_player(_, value)
+      when value > 0,
+      do: {:ok, value - 1}
+
+  def remove_player(:right, right)
+      when right > 0,
+      do: {:ok, right - 1}
+
+  def remove_player(_, _),
+    do: {:error, :invalid_player}
+
+  def players_ready?(left, right),
+    do: left && left > 0 && right && right > 0
+end

--- a/apps/pong/lib/pong/renderer.ex
+++ b/apps/pong/lib/pong/renderer.ex
@@ -65,7 +65,7 @@ defmodule Pong.Renderer do
   end
 
   def handle_info(:work, state) do
-    {game, events} = Pong.Engines.Singles.consume()
+    {game, events} = Pong.Engines.Multi.consume()
 
     broadcast(state.subscriptions, {"data", game})
     for event <- events, do: broadcast(state.subscriptions, event)

--- a/apps/pong/test/pong/engines/multi_test.exs
+++ b/apps/pong/test/pong/engines/multi_test.exs
@@ -1,0 +1,52 @@
+defmodule Pong.Engines.MultiTest do
+  use ExUnit.Case
+  doctest Pong.Engines.Multi
+
+  alias Pong.Engines.Multi
+
+  describe "add_player/1" do
+    test "errors if the game is full" do
+      assert {:error, :game_full} = Multi.add_player(300, 300)
+    end
+
+    test "adds the left player if no players have joined" do
+      assert {:ok, :left, 1} = Multi.add_player(nil, nil)
+    end
+
+    test "adds the right player if there is a left player" do
+      assert {:ok, :right, 1} = Multi.add_player(1, nil)
+    end
+
+    test "prioritizes adding the left player" do
+      assert {:ok, :left, 2} = Multi.add_player(1, 1)
+    end
+
+    test "adds the right player if there are more left players" do
+      assert {:ok, :right, 2} = Multi.add_player(5, 1)
+    end
+  end
+
+  describe "remove_player/2" do
+    test "decreases the correct player count" do
+      assert {:ok, 2} = Multi.remove_player(:left, 3)
+      assert {:ok, 2} = Multi.remove_player(:right, 3)
+    end
+
+    test "errors if the player hasn't joined" do
+      assert {:error, :invalid_player} = Multi.remove_player(:left, nil)
+    end
+  end
+
+  describe "players_ready?/0" do
+    test "is true if there are players on both sides" do
+      assert Multi.players_ready?(2, 1)
+    end
+
+    test "is false if there are less than two players" do
+      refute Multi.players_ready?(1, 0)
+      refute Multi.players_ready?(0, 1)
+      refute Multi.players_ready?(1, nil)
+      refute Multi.players_ready?(nil, 1)
+    end
+  end
+end

--- a/apps/pong/test/pong/renderer_test.exs
+++ b/apps/pong/test/pong/renderer_test.exs
@@ -2,7 +2,7 @@ defmodule Pong.RendererTest do
   use ExUnit.Case
   doctest Pong.Renderer
 
-  alias Pong.Engines.Singles, as: Engine
+  alias Pong.Engines.Multi, as: Engine
   alias Pong.Renderer
 
   import Pong.Factory


### PR DESCRIPTION
Why:

* We want chaos

This change addresses the need by:

* Adding a multiplayer engine.
* Adapting the engine to work with engines that don't end after a player
left.