### PR TITLE
Leave channels when game is over

### DIFF
--- a/apps/client/frontend/components/GameRoom/index.js
+++ b/apps/client/frontend/components/GameRoom/index.js
@@ -55,6 +55,8 @@ export default class GameRoom extends Component {
     this.metadataChannel.on('game_over', () => {
       this.setState({ gameOver: true });
 
+      this.leaveChannel();
+
       setTimeout(() => {
         window.location.href = '/';
       }, 3000);


### PR DESCRIPTION
Exit the channels immediatly when we receive the `game_over` event.